### PR TITLE
Store states in different accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terragrunt-cache

--- a/terragrunt-way/dev/common.hcl
+++ b/terragrunt-way/dev/common.hcl
@@ -1,0 +1,5 @@
+inputs = {
+    aws_region = "us-east-1"
+    iam_role   = "arn:aws:iam::639130796919:role/OrganizationAccountAccessRole"
+    account_id = "639130796919"
+}

--- a/terragrunt-way/dev/common.tfvars
+++ b/terragrunt-way/dev/common.tfvars
@@ -1,2 +1,0 @@
-aws_region = "us-east-1"
-iam_role   = "arn:aws:iam::639130796919:role/OrganizationAccountAccessRole"

--- a/terragrunt-way/dev/s3-objects/.terraform.lock.hcl
+++ b/terragrunt-way/dev/s3-objects/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 3.75.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/dev/s3/.terraform.lock.hcl
+++ b/terragrunt-way/dev/s3/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 4.5.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/prod/common.hcl
+++ b/terragrunt-way/prod/common.hcl
@@ -1,0 +1,5 @@
+inputs = {
+    aws_region = "us-west-1"
+    iam_role   = "arn:aws:iam::032823347814:role/OrganizationAccountAccessRole"
+    account_id = "032823347814"
+}

--- a/terragrunt-way/prod/common.tfvars
+++ b/terragrunt-way/prod/common.tfvars
@@ -1,2 +1,0 @@
-aws_region = "us-west-1"
-iam_role   = "arn:aws:iam::032823347814:role/OrganizationAccountAccessRole"

--- a/terragrunt-way/prod/s3-objects/.terraform.lock.hcl
+++ b/terragrunt-way/prod/s3-objects/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 3.75.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/prod/s3/.terraform.lock.hcl
+++ b/terragrunt-way/prod/s3/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 4.5.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/root/common.hcl
+++ b/terragrunt-way/root/common.hcl
@@ -1,0 +1,5 @@
+inputs = {
+    aws_region = "us-west-1"
+    iam_role   = ""
+    account_id = "111"
+}

--- a/terragrunt-way/root/common.tfvars
+++ b/terragrunt-way/root/common.tfvars
@@ -1,2 +1,0 @@
-aws_region = "us-west-1"
-iam_role   = ""

--- a/terragrunt-way/root/s3-objects/.terraform.lock.hcl
+++ b/terragrunt-way/root/s3-objects/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 3.75.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/root/s3/.terraform.lock.hcl
+++ b/terragrunt-way/root/s3/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.1"
+  constraints = ">= 4.5.0"
+  hashes = [
+    "h1:leEZu+Kv9JIvGpt8SfFkjftdR8KrFMkbUMQVnH0kvFk=",
+  ]
+}

--- a/terragrunt-way/terragrunt.hcl
+++ b/terragrunt-way/terragrunt.hcl
@@ -7,40 +7,15 @@ remote_state {
   }
 
   config = {
-    bucket  = "adv-it-terragrunt-remote-state"
-    region  = "us-west-2"
+    bucket  = "adv-it-terragrunt-remote-state-${local.provider.account_id}"
+    region  = "${local.provider.aws_region}"
     key     = "${path_relative_to_include()}/terraform.tfstate"
     encrypt = true
   }
 }
 
-# Generate config.tf file with provider configuration
-generate "my_config" {
-  path      = "_config.tf"
-  if_exists = "overwrite"
+iam_role       = local.provider.iam_role
 
-  contents = <<EOF
-provider "aws" {
-  region  = var.aws_region
-  assume_role {
-    role_arn = var.iam_role
-  }
-}
-
-variable "aws_region" {}
-variable "iam_role" {}
-  
-EOF
-}
-
-
-# Load Variables
-terraform {
-  extra_arguments "common_vars" {
-    commands = get_terraform_commands_that_need_vars()
-
-    required_var_files = [
-      find_in_parent_folders("common.tfvars"),
-    ]
-  }
+locals {
+  provider = read_terragrunt_config("./../common.hcl", {inputs: {iam_role: "", account_id: "", aws_region: ""}}).inputs
 }


### PR DESCRIPTION
Here is a small suggestion to simplify things out.

Key difference: state files are stored not in the root account s3 bucket but in the individual ones. For me that makes more sense, especially when multiple teams have their own playgrounds.
